### PR TITLE
*: fix imports to make go getable

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,8 +22,6 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/go.crypto/openpgp"
-	"code.google.com/p/go.crypto/openpgp/clearsign"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -32,6 +30,9 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/clearsign"
 )
 
 /*


### PR DESCRIPTION
The official import paths for the openpgp sub repo is `golang.org/x/crypto/openpgp`. I'm getting an error with the current path.

```
$ go get github.com/brianredbeard/gpget
package code.google.com/p/go.crypto/openpgp: unable to detect version control system for code.google.com/ path
package code.google.com/p/go.crypto/openpgp/clearsign: unable to detect version control system for code.google.com/ path
```
